### PR TITLE
Fixed auto off parameter range for Fibaro FGS-222

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs222.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs222.xml
@@ -70,20 +70,20 @@
 
 		<Parameter>
 			<Index>4</Index>
-			<Type>byte</Type>
+			<Type>short</Type>
 			<Default>20</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Relay 1: OFF-delay time (10ms steps)</Label>			
-			<Help lang="en">Automatic turning off relay 1 after set time, in 10ms increments (default: 200ms)</Help>
+			<Help lang="en">Automatic turning off relay 1 after set time, in 100ms increments (default: 2s)</Help>
 		</Parameter>
 
 		<Parameter>
 			<Index>5</Index>
-			<Type>byte</Type>
+			<Type>short</Type>
 			<Default>20</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Relay 2: OFF-delay time (10ms steps)</Label>			
-			<Help lang="en">Automatic turning off relay 2 after set time, in 10ms increments (default: 200ms)</Help>
+			<Help lang="en">Automatic turning off relay 2 after set time, in 100ms increments (default: 2s)</Help>
 		</Parameter>
 
 		<Parameter>


### PR DESCRIPTION
The parameter range in the FGS 222 is actually 2 bytes, and the value is not in 10ms steps, but in 100ms steps.